### PR TITLE
Prepare for 1.0 release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ matrix:
       env: TOXENV=lint
     - python: "2.7"
       env: TOXENV=py27-1.8
-    - python: "3.5"
+    - python: "3.4"
       env: TOXENV=py34-1.8
     - python: "2.7"
       env: TOXENV=py27-1.9

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,11 +1,18 @@
 Release History
 ---------------
 
+v1.0 - 2020-08-12
+^^^^^^^^^^^^^^^^^
+* No new features, but marking the project as mature since neither DNT or this
+  implementation is likely to change, except to follow Django releases.
+* Add support for Django 2.0, 2.1, and 2.2
+* Add support for Python 3.7
+
 v0.2.0 - 2017-02-17
 ~~~~~~~~~~~~~~~~~~~
 * Supported Django versions: 1.8, 1.9, 1.10, and 1.11
 * Supported Python versions: 2.7, 3.3, 3.4. 3.5, 3.6
-* Add "DNT" to Vary header in response (eillarra)
+* Add "DNT" to Vary header in response (`eillarra <https://github.com/eillarra>`_)
 
 v0.1.0 - 2011-02-16
 ~~~~~~~~~~~~~~~~~~~

--- a/Makefile
+++ b/Makefile
@@ -50,14 +50,10 @@ sdist:
 	pyroma dist/`ls -t dist | grep tar.gz | head -n1`
 
 release: clean sdist
-	twine register dist/*.tar.gz
-	twine register dist/*.whl
 	twine upload dist/*
 	python -m webbrowser -n https://pypi.python.org/pypi/django-dnt
 
 # Add [test] section to ~/.pypirc, https://testpypi.python.org/pypi
 test-release: clean sdist
-	twine register --repository test dist/*.tar.gz
-	twine register --repository test dist/*.whl
 	twine upload --repository test dist/*
 	python -m webbrowser -n https://testpypi.python.org/pypi/django-dnt

--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,8 @@ Django-DNT
 
 .. Omit badges from docs
 
-Do Not Track offers an easy way to pay attention to the ``DNT`` HTTP header. If
+``django-dnt`` offers an easy way to pay attention to the ``DNT``
+(`Do Not Track <https://en.wikipedia.org/wiki/Do_Not_Track>`_) HTTP header. If
 users are sending ``DNT: 1``, ``DoNotTrackMiddleware`` will set ``request.DNT =
 True``, else it will set ``request.DNT = False``.
 

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ def long_description():
 
 setup(
     name='django-dnt',
-    version='0.2.0',
+    version='1.0',
     description=description + '.',
     long_description=long_description(),
     author='James Socol',
@@ -66,7 +66,7 @@ setup(
     zip_safe=False,
     keywords='django-dnt dnt do not track',
     classifiers=[
-        'Development Status :: 4 - Beta',
+        'Development Status :: 6 - Mature',
         'Environment :: Web Environment',
         'Environment :: Web Environment :: Mozilla',
         'Framework :: Django',

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,8 @@ setup(
     long_description=long_description(),
     author='James Socol',
     author_email='james@mozilla.com',
+    maintainer='John Whitlock',
+    maintainer_email='jwhitlock@mozilla.com',
     url='http://github.com/mozilla/django-dnt',
     license='BSD',
     packages=['dnt'],


### PR DESCRIPTION
This project is already feature complete and used in production websites, so we're embracing [semantic versioning](https://semver.org) with a 1.0 version, and updating the PyPI classifier from "beta" to "mature".